### PR TITLE
1 reset pyprojecttoml version in install script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: docformatter
         args: [--in-place, --wrap-summaries=120, --wrap-descriptions=120, --close-quotes-on-newline]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.2
+    rev: v0.9.5
     hooks:
       - id: ruff
         args: [--fix]

--- a/configure_template.py
+++ b/configure_template.py
@@ -43,6 +43,7 @@ def update_pyproject_toml(package_name: str, project_description: str, author_na
     name_match = re.search(r'name = "(.*)"', file_content)
     description_match = re.search(r'description = "(.*)"', file_content)
     authors_match = re.search(r'authors = \[{name = "(.*)", email = "(.*)"}\]', file_content)
+    version_match = re.search(r'version = "(.*)"', file_content)
 
     if not name_match or not description_match or not authors_match:
         print("Failed to match values in pyproject.toml.")
@@ -52,6 +53,7 @@ def update_pyproject_toml(package_name: str, project_description: str, author_na
     file_content = file_content.replace(description_match.group(1), project_description, 1)
     file_content = file_content.replace(authors_match.group(1), author_name, 1)
     file_content = file_content.replace(authors_match.group(2), author_email, 1)
+    file_content = file_content.replace(version_match.group(1), "0.0.0", 1)
 
     with open("pyproject.toml", "w") as file:
         file.write(file_content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "A robust template for Python projects following the src layout de
 readme = "README.md"
 authors = [{name = "Christopher McMahon", email = "CCarrMcMahon@gmail.com"}]
 classifiers = ["Programming Language :: Python :: 3.12"]
-version = "1.1.1"
+version = "1.1.2"
 requires-python = ">=3.12.2"
 dependencies = ["setuptools>=75.8.0"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = ["setuptools>=75.8.0"]
 
 [project.optional-dependencies]
 dev = ["pre-commit>=4.1.0"]
-lint = ["ruff>=0.9.2"]
+lint = ["ruff>=0.9.5"]
 tests = ["pytest>=8.3.4", "pytest-html>=4.1.1"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

* Fixed a bug where the version field in pyproject.toml wasn't updated during the initial installation process.
* Upgraded `ruff` to the latest release of `v0.9.5`

## Tickets

Closes #1 